### PR TITLE
[Search] Decouple SearchFieldCategory from DocumentFieldCategory.cs

### DIFF
--- a/Kinetix/Kinetix.Search/ComponentModel/DocumentFieldAttribute.cs
+++ b/Kinetix/Kinetix.Search/ComponentModel/DocumentFieldAttribute.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Kinetix.Search.ComponentModel
+{
+
+    /// <summary>
+    /// Attribut de décoration de propriété de document de moteur de recherche.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class DocumentFieldAttribute : Attribute
+    {
+
+        /// <summary>
+        /// Créé une nouvelle instance de DocumentFieldCategory.
+        /// </summary>
+        /// <param name="category">Catégorie.</param>
+        public DocumentFieldAttribute(DocumentFieldCategory category)
+        {
+            this.Category = category;
+        }
+
+        /// <summary>
+        /// Catégorie du champ.
+        /// </summary>
+        public DocumentFieldCategory Category
+        {
+            get;
+            private set;
+        }
+    }
+}

--- a/Kinetix/Kinetix.Search/ComponentModel/DocumentFieldCategory.cs
+++ b/Kinetix/Kinetix.Search/ComponentModel/DocumentFieldCategory.cs
@@ -1,0 +1,23 @@
+﻿namespace Kinetix.Search.ComponentModel
+{
+    /// <summary>
+    /// Catégorie de champ pour le moteur de recherche.
+    /// </summary>
+    public enum DocumentFieldCategory
+    {
+        /// <summary>
+        /// Champ ID 
+        /// </summary>
+        Id,
+
+        /// <summary>
+        /// Champ de recherche 
+        /// </summary>
+        Search,
+
+        /// <summary>
+        /// Champ de filtrage de sécurité 
+        /// </summary>
+        Security,
+    }
+}

--- a/Kinetix/Kinetix.Search/ComponentModel/SearchFieldCategory.cs
+++ b/Kinetix/Kinetix.Search/ComponentModel/SearchFieldCategory.cs
@@ -1,14 +1,11 @@
-﻿namespace Kinetix.Search.ComponentModel {
+﻿namespace Kinetix.Search.ComponentModel
+{
 
     /// <summary>
     /// Catégorie de champ pour le moteur de recherche.
     /// </summary>
-    public enum SearchFieldCategory {
-
-        /// <summary>
-        /// Champ ID : indexé et stocké tel quel.
-        /// </summary>
-        Id,
+    public enum SearchFieldCategory
+    {
 
         /// <summary>
         /// Champ de résultat, destiné à l'affichage : non indexé, stocké.
@@ -18,12 +15,7 @@
         /// <summary>
         /// Champ de recherche : indexé tokenisé en minuscule, non stocké.
         /// </summary>
-        Search,
-
-        /// <summary>
-        /// Champ de filtrage de sécurité : indexé tokenisé en minuscule, non stocké.
-        /// </summary>
-        Security,
+        TextSearch,
 
         /// <summary>
         /// Champ de tri : indexé en minuscule, non stocké.
@@ -31,18 +23,18 @@
         Sort,
 
         /// <summary>
-        /// Champ de facette : indexé tel quel, non stocké.
+        /// Champ de Facette ou Filtre : indexé tel quel, non stocké.
         /// </summary>
-        Facet,
+        Term,
 
         /// <summary>
-        /// Champ de facette contenant une liste de valeurs : indexé tel quel, non stocké.
+        /// Champ de Facette ou Fitlre contenant une liste de valeurs : indexé tel quel, non stocké.
         /// </summary>
-        ListFacet,
+        ListTerm,
 
         /// <summary>
-        /// Champ utilisé pour filtrer les résultats de recherche.
+        /// Champ laissé par défaut.
         /// </summary>
-        Filter
+        None,
     }
 }

--- a/Kinetix/Kinetix.Search/Elastic/ElasticMappingFactory.cs
+++ b/Kinetix/Kinetix.Search/Elastic/ElasticMappingFactory.cs
@@ -1,14 +1,16 @@
-﻿using System;
-using Kinetix.Search.ComponentModel;
+﻿using Kinetix.Search.ComponentModel;
 using Kinetix.Search.MetaModel;
 using Nest;
+using System;
 
-namespace Kinetix.Search.Elastic {
+namespace Kinetix.Search.Elastic
+{
 
     /// <summary>
     /// Usine à mapping ElasticSearch.
     /// </summary>
-    public class ElasticMappingFactory {
+    public class ElasticMappingFactory
+    {
 
         /// <summary>
         /// Obtient le mapping de champ Elastic pour une catégorie donnée.
@@ -18,21 +20,25 @@ namespace Kinetix.Search.Elastic {
         /// <returns>Mapping de champ.</returns>
         /// <typeparam name="T">Type du document.</typeparam>
         public PropertiesDescriptor<T> AddField<T>(PropertiesDescriptor<T> selector, DocumentFieldDescriptor field)
-            where T : class {
+            where T : class
+        {
             var fieldName = field.FieldName;
 
             /* TODO Externaliser. */
 
-            switch (field.Category) {
+            switch (field.SearchCategory)
+            {
                 case SearchFieldCategory.Result:
-                    if (field.PropertyType == typeof(DateTime?)) {
+                    if (field.PropertyType == typeof(DateTime?))
+                    {
                         return selector.Date(x => x
                             .Name(fieldName)
                             .Index(false)
                             .Store(true));
                     }
 
-                    if (field.PropertyType == typeof(int?)) {
+                    if (field.PropertyType == typeof(int?))
+                    {
                         return selector.Number(x => x
                             .Name(fieldName)
                             .Type(NumberType.Integer)
@@ -40,7 +46,8 @@ namespace Kinetix.Search.Elastic {
                             .Store(true));
                     }
 
-                    if (field.PropertyType == typeof(decimal?)) {
+                    if (field.PropertyType == typeof(decimal?))
+                    {
                         return selector.Number(x => x
                             .Name(fieldName)
                             .Type(NumberType.Double)
@@ -52,28 +59,24 @@ namespace Kinetix.Search.Elastic {
                         .Name(fieldName)
                         .Index(false)
                         .Store(true));
-                case SearchFieldCategory.Search:
+
+                case SearchFieldCategory.TextSearch:
                     /* Champ de recherche textuelle full-text. */
                     return selector.Text(x => x
                         .Name(fieldName)
                         .Index(true)
                         .Store(false)
                         .Analyzer("text_fr"));
-                case SearchFieldCategory.Security:
-                    /* Champ de filtrage de sécurité : listes de code. */
-                    /* TODO : faire un mapping plus spécifique ? */
-                    return selector.Text(x => x
-                        .Name(fieldName)
-                        .Index(true)
-                        .Store(true)
-                        .Analyzer("text_fr"));
-                case SearchFieldCategory.Facet:
-                    /* Champ de facette. */
-                    if (field.PropertyType == typeof(DateTime?)) {
-                        throw new ElasticException("Le type DateTime n'est pas supporté pour le champ de facette " + field.FieldName);
+
+                case SearchFieldCategory.Term:
+                    /* Champ de facette/filtre. */
+                    if (field.PropertyType == typeof(DateTime?))
+                    {
+                        throw new ElasticException("Le type DateTime n'est pas supporté pour les champ de Term " + field.FieldName);
                     }
 
-                    if (field.PropertyType == typeof(decimal?)) {
+                    if (field.PropertyType == typeof(decimal?))
+                    {
                         return selector.Number(x => x
                             .Name(fieldName)
                             .Index(true)
@@ -84,21 +87,25 @@ namespace Kinetix.Search.Elastic {
                         .Name(fieldName)
                         .Index(true)
                         .Store(false));
-                case SearchFieldCategory.ListFacet:
+
+                case SearchFieldCategory.ListTerm:
                     return selector.Text(x => x
                         .Name(fieldName)
                         .Index(true)
                         .Store(false)
                         .Analyzer("text_fr"));
+
                 case SearchFieldCategory.Sort:
-                    if (field.PropertyType == typeof(DateTime?)) {
+                    if (field.PropertyType == typeof(DateTime?))
+                    {
                         return selector.Date(x => x
                             .Name(fieldName)
                             .Index(true)
                             .Store(false));
                     }
 
-                    if (field.PropertyType == typeof(decimal?)) {
+                    if (field.PropertyType == typeof(decimal?))
+                    {
                         return selector.Number(x => x
                             .Name(fieldName)
                             .Index(true)
@@ -109,27 +116,12 @@ namespace Kinetix.Search.Elastic {
                         .Name(fieldName)
                         .Index(true)
                         .Store(false));
-                case SearchFieldCategory.Filter:
-                    /* Champ filtre. */
-                    if (field.PropertyType == typeof(DateTime?)) {
-                        throw new ElasticException("Le type DateTime n'est pas supporté pour le champ de filtrage " + field.FieldName);
-                    }
 
-                    if (field.PropertyType == typeof(decimal?)) {
-                        return selector.Number(x => x
-                            .Name(fieldName)
-                            .Index(true)
-                            .Store(false));
-                    }
-
-                    return selector.Keyword(x => x
-                        .Name(fieldName)
-                        .Index(true)
-                        .Store(false));
-                case SearchFieldCategory.Id:
+                case SearchFieldCategory.None:
                     return selector;
+
                 default:
-                    throw new NotSupportedException("Category not supported : " + field.Category);
+                    throw new NotSupportedException("Category not supported : " + field.SearchCategory);
             }
         }
     }

--- a/Kinetix/Kinetix.Search/Kinetix.Search.csproj
+++ b/Kinetix/Kinetix.Search/Kinetix.Search.csproj
@@ -60,6 +60,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Broker\MonitoredBroker.cs" />
+    <Compile Include="ComponentModel\DocumentFieldAttribute.cs" />
+    <Compile Include="ComponentModel\DocumentFieldCategory.cs" />
     <Compile Include="Config\SearchDataSourceCollection.cs" />
     <Compile Include="Config\SearchDataSourceElement.cs" />
     <Compile Include="Config\SearchSettings.cs" />

--- a/Kinetix/Kinetix.Search/MetaModel/DocumentDefinition.cs
+++ b/Kinetix/Kinetix.Search/MetaModel/DocumentDefinition.cs
@@ -1,13 +1,16 @@
-﻿using System;
-using Kinetix.Search.ComponentModel;
+﻿using Kinetix.Search.ComponentModel;
+using System;
+using System.Linq;
 
-namespace Kinetix.Search.MetaModel {
+namespace Kinetix.Search.MetaModel
+{
 
     /// <summary>
     /// Définition d'un bean.
     /// </summary>
     [Serializable]
-    public class DocumentDefinition {
+    public class DocumentDefinition
+    {
 
         /// <summary>
         /// Constructeur.
@@ -15,19 +18,22 @@ namespace Kinetix.Search.MetaModel {
         /// <param name="beanType">Type du bean.</param>
         /// <param name="properties">Collection de propriétés.</param>
         /// <param name="documentTypeName">Nom du contrat (table).</param>
-        internal DocumentDefinition(Type beanType, DocumentFieldDescriptorCollection properties, string documentTypeName) {
+        internal DocumentDefinition(Type beanType, DocumentFieldDescriptorCollection properties, string documentTypeName)
+        {
             this.BeanType = beanType;
             this.Fields = properties;
             this.DocumentTypeName = documentTypeName;
-            foreach (DocumentFieldDescriptor property in properties) {
-                switch (property.Category) {
-                    case SearchFieldCategory.Id:
+            foreach (DocumentFieldDescriptor property in properties)
+            {
+                switch (property.DocumentCategory)
+                {
+                    case DocumentFieldCategory.Id:
                         this.PrimaryKey = property;
                         break;
-                    case SearchFieldCategory.Search:
+                    case DocumentFieldCategory.Search:
                         this.TextField = property;
                         break;
-                    case SearchFieldCategory.Security:
+                    case DocumentFieldCategory.Security:
                         this.SecurityField = property;
                         break;
                     default:
@@ -35,7 +41,23 @@ namespace Kinetix.Search.MetaModel {
                 }
             }
 
-            if (this.PrimaryKey == null) {
+            if (properties.Where(prop => DocumentFieldCategory.Search.Equals(prop.DocumentCategory)).Count() > 1)
+            {
+                throw new NotSupportedException($"{beanType} has multiple Search fields");
+            }
+
+            if (properties.Where(prop => DocumentFieldCategory.Id.Equals(prop.DocumentCategory)).Count() > 1)
+            {
+                throw new NotSupportedException($"{beanType} has multiple Id fields");
+            }
+
+            if (properties.Where(prop => DocumentFieldCategory.Security.Equals(prop.DocumentCategory)).Count() > 1)
+            {
+                throw new NotSupportedException($"{beanType} has multiple Security fields");
+            }
+
+            if (this.PrimaryKey == null)
+            {
                 throw new NotSupportedException(beanType + " has no primary key defined.");
             }
         }
@@ -43,7 +65,8 @@ namespace Kinetix.Search.MetaModel {
         /// <summary>
         /// Retourne le type du bean.
         /// </summary>
-        public Type BeanType {
+        public Type BeanType
+        {
             get;
             private set;
         }
@@ -51,7 +74,8 @@ namespace Kinetix.Search.MetaModel {
         /// <summary>
         /// Retourne le nom du contrat.
         /// </summary>
-        public string DocumentTypeName {
+        public string DocumentTypeName
+        {
             get;
             private set;
         }
@@ -59,7 +83,8 @@ namespace Kinetix.Search.MetaModel {
         /// <summary>
         /// Retourne la clef primaire si elle existe.
         /// </summary>
-        public DocumentFieldDescriptor PrimaryKey {
+        public DocumentFieldDescriptor PrimaryKey
+        {
             get;
             private set;
         }
@@ -67,7 +92,8 @@ namespace Kinetix.Search.MetaModel {
         /// <summary>
         /// Retourne la propriété de recherche textuelle.
         /// </summary>
-        public DocumentFieldDescriptor TextField {
+        public DocumentFieldDescriptor TextField
+        {
             get;
             private set;
         }
@@ -75,7 +101,8 @@ namespace Kinetix.Search.MetaModel {
         /// <summary>
         /// Retourne la propriété de filtrage de sécurité.
         /// </summary>
-        public DocumentFieldDescriptor SecurityField {
+        public DocumentFieldDescriptor SecurityField
+        {
             get;
             private set;
         }
@@ -83,7 +110,8 @@ namespace Kinetix.Search.MetaModel {
         /// <summary>
         /// Retourne la liste des propriétés d'un bean.
         /// </summary>
-        public DocumentFieldDescriptorCollection Fields {
+        public DocumentFieldDescriptorCollection Fields
+        {
             get;
             private set;
         }

--- a/Kinetix/Kinetix.Search/MetaModel/DocumentDescriptor.cs
+++ b/Kinetix/Kinetix.Search/MetaModel/DocumentDescriptor.cs
@@ -57,14 +57,17 @@ namespace Kinetix.Search.MetaModel {
                     throw new NotSupportedException("Missing SearchFieldAttribute on property " + beanType + "." + property.Name);
                 }
 
-                var category = fieldAttr.Category;
+                DocumentFieldAttribute docAttr = (DocumentFieldAttribute)property.Attributes[typeof(DocumentFieldAttribute)];
+
+                var fieldCategory = fieldAttr.Category;
 
                 string fieldName = ToCamelCase(property.Name);
                 DocumentFieldDescriptor description = new DocumentFieldDescriptor(
                             property.Name,
                             fieldName,
                             property.PropertyType,
-                            category);
+                            docAttr?.Category,
+                            fieldCategory);
 
                 coll[description.PropertyName] = description;
             }

--- a/Kinetix/Kinetix.Search/MetaModel/DocumentFieldDescriptor.cs
+++ b/Kinetix/Kinetix.Search/MetaModel/DocumentFieldDescriptor.cs
@@ -1,14 +1,16 @@
-﻿using System;
+﻿using Kinetix.Search.ComponentModel;
+using System;
 using System.ComponentModel;
-using Kinetix.Search.ComponentModel;
 
-namespace Kinetix.Search.MetaModel {
+namespace Kinetix.Search.MetaModel
+{
 
     /// <summary>
     /// Classe de description d'une propriété.
     /// </summary>
     [Serializable]
-    public sealed class DocumentFieldDescriptor {
+    public sealed class DocumentFieldDescriptor
+    {
 
         /// <summary>
         /// Crée une nouvelle instance.
@@ -16,18 +18,22 @@ namespace Kinetix.Search.MetaModel {
         /// <param name="propertyName">Nom de la propriété.</param>
         /// <param name="fieldName">Nom du champ dans le document.</param>
         /// <param name="propertyType">Type de la propriété.</param>
-        /// <param name="category">Domaine de la propriété.</param>
-        internal DocumentFieldDescriptor(string propertyName, string fieldName, Type propertyType, SearchFieldCategory category) {
+        /// <param name="docCategory">Domaine de la propriété.</param>
+        /// <param name="fieldCategory">Domaine de la propriété.</param>
+        internal DocumentFieldDescriptor(string propertyName, string fieldName, Type propertyType, DocumentFieldCategory? docCategory, SearchFieldCategory fieldCategory)
+        {
             this.PropertyName = propertyName;
             this.FieldName = fieldName;
             this.PropertyType = propertyType;
-            this.Category = category;
+            this.DocumentCategory = docCategory;
+            this.SearchCategory = fieldCategory;
         }
 
         /// <summary>
         /// Obtient le nom de la propriété.
         /// </summary>
-        public string PropertyName {
+        public string PropertyName
+        {
             get;
             private set;
         }
@@ -35,7 +41,8 @@ namespace Kinetix.Search.MetaModel {
         /// <summary>
         /// Nom du champ dans le document (camel case).
         /// </summary>
-        public string FieldName {
+        public string FieldName
+        {
             get;
             private set;
         }
@@ -43,15 +50,26 @@ namespace Kinetix.Search.MetaModel {
         /// <summary>
         /// Obtient le type de la propriété.
         /// </summary>
-        public Type PropertyType {
+        public Type PropertyType
+        {
             get;
             private set;
         }
 
         /// <summary>
-        /// Catégorie de field.
+        /// Catégorie de field de search.
         /// </summary>
-        public SearchFieldCategory Category {
+        public SearchFieldCategory SearchCategory
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Catégorie de field de document.
+        /// </summary>
+        public DocumentFieldCategory? DocumentCategory
+        {
             get;
             private set;
         }
@@ -61,7 +79,8 @@ namespace Kinetix.Search.MetaModel {
         /// </summary>
         /// <param name="bean">Objet.</param>
         /// <returns>Valeur.</returns>
-        public object GetValue(object bean) {
+        public object GetValue(object bean)
+        {
             object value = TypeDescriptor.GetProperties(bean)[this.PropertyName].GetValue(bean);
             return value;
         }
@@ -71,7 +90,8 @@ namespace Kinetix.Search.MetaModel {
         /// </summary>
         /// <param name="bean">Objet.</param>
         /// <param name="value">Valeur.</param>
-        public void SetValue(object bean, object value) {
+        public void SetValue(object bean, object value)
+        {
             PropertyDescriptor descriptor = TypeDescriptor.GetProperties(bean)[this.PropertyName];
             descriptor.SetValue(bean, value);
         }
@@ -80,7 +100,8 @@ namespace Kinetix.Search.MetaModel {
         /// Retourne une chaîne de caractère représentant l'objet.
         /// </summary>
         /// <returns>Chaîne de caractère représentant l'objet.</returns>
-        public override string ToString() {
+        public override string ToString()
+        {
             return this.PropertyName;
         }
     }


### PR DESCRIPTION
Fix #18

**[BC]** Split `SearchFieldCategory` in two : `DocumentFieldCategory` & `SearchFieldCategory`

### DocumentFieldCategory

Is used to detect which are the fields to use as `Id`, `Search` and `Security`

### SearchFieldCategory

Is used to know how to store/index & then query fields

New types are :

-  Result
-  TextSearch
-  Sort
-  Term
-  ListTerm
-  None

**Note** : `Filter`, `Facet` and `ListFacet` no longer exists. 

## [BC] 

Fields still need to have a `SearchFieldAttribute` so you need to update them as follow :
- **Search** : replace with `[DocumentField(DocumentFieldCategory.Search)]` and `[SearchField(SearchFieldCategory.TextSearch)]`
- **Security** : replace with `[DocumentField(DocumentFieldCategory.Security)]` and `[SearchField(SearchFieldCategory.XXX)]`. it depends, you are now free to use the one you need
- **Id** : replace with `[DocumentField(DocumentFieldCategory.Id)]` and `[SearchField(SearchFieldCategory.None)]`. haven't come with a better one
- **Facet** : replace with `[SearchField(DocumentFieldCategory.Term)]`
- **Filter** : replace with `[SearchField(DocumentFieldCategory.Term)]`
- **ListFacet** : replace with `[SearchField(DocumentFieldCategory.ListTerm)]`
- **Result** : stays the same
- **Sort** : stays the same

## Benefit

`Filter` can now be done with : `Term`, `ListTerm` and `TextSearch`. Before you could hack by using `ListFacet` but they was no way to use a `TextSearch` like.