### PR TITLE
Fix reference object saving on a custom language.

### DIFF
--- a/Kinetix/Kinetix.Broker/ReferenceBroker.cs
+++ b/Kinetix/Kinetix.Broker/ReferenceBroker.cs
@@ -69,7 +69,7 @@ namespace Kinetix.Broker {
             ColumnSelector filteredColumnSelector = columnSelector;
             if (definition.PrimaryKey.GetValue(bean) != null && lanCode != defaultLanguage && definition.IsTranslatable) {
                 string[] notTranslatablePropertyList = definition.Properties.Where(x => !x.PropertyType.Name.Equals(typeof(ChangeAction).Name)
-                        && x.MemberName != null && !x.IsTranslatable).Select(p => p.PropertyName).ToArray();
+                        && x.MemberName != null && !x.IsTranslatable).Select(p => p.MemberName).ToArray();
                 string[] filteredPropertyList = columnSelector == null ? notTranslatablePropertyList : notTranslatablePropertyList.Intersect(columnSelector.ColumnList).ToArray();
                 filteredColumnSelector = new ColumnSelector(filteredPropertyList);
             }

--- a/Kinetix/Tests/Kinetix.Broker.Test/Kinetix.Broker.Test.csproj
+++ b/Kinetix/Tests/Kinetix.Broker.Test/Kinetix.Broker.Test.csproj
@@ -54,6 +54,18 @@
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity.RegistrationByConvention, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.RegistrationByConvention.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\Build\Lib\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll</HintPath>
     </Reference>
@@ -66,6 +78,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Linq" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -88,10 +101,18 @@
     <Compile Include="ModificationDateRuleTest.cs" />
     <Compile Include="ModificationUserRuleTest.cs" />
     <Compile Include="OptimisticLockingBrokerExceptionTest.cs" />
+    <Compile Include="ReferenceBroker\ReferenceAccessors.cs" />
+    <Compile Include="ReferenceBroker\ReferenceBean.cs" />
+    <Compile Include="ReferenceBroker\IReferenceAccessors.cs" />
+    <Compile Include="ReferenceBroker\ServiceResourceWriterMock.cs" />
+    <Compile Include="ReferenceBroker\ServiceResourceLoaderMock.cs" />
+    <Compile Include="ReferenceBroker\ReferenceBrokerTestHelper.cs" />
+    <Compile Include="ReferenceBroker\ReferenceBrokerMock.cs" />
     <Compile Include="SortParamTest.cs" />
     <Compile Include="SqlServerStoreTest.cs" />
     <Compile Include="SqlStoreTest.cs" />
     <Compile Include="SqlTestStore.cs" />
+    <Compile Include="ReferenceBroker\ReferenceBrokerTest.cs" />
     <Compile Include="StandardBrokerTest.cs" />
     <Compile Include="StateBean.cs" />
     <Compile Include="TestDataReader.cs" />
@@ -120,6 +141,10 @@
     <ProjectReference Include="..\..\Kinetix.Monitoring\Kinetix.Monitoring.csproj">
       <Project>{E5CA12F8-EA8D-45B2-9EED-9592F4833478}</Project>
       <Name>Kinetix.Monitoring</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Kinetix.ServiceModel\Kinetix.ServiceModel.csproj">
+      <Project>{A7A2C429-2E86-4830-84BD-1477D68F1401}</Project>
+      <Name>Kinetix.ServiceModel</Name>
     </ProjectReference>
     <ProjectReference Include="..\Kinetix.Data.SqlClient.Test\Kinetix.Data.SqlClient.Test.csproj">
       <Project>{9BB7D0F2-69F8-4951-B1AE-CF93F614C107}</Project>

--- a/Kinetix/Tests/Kinetix.Broker.Test/ReferenceBroker/IReferenceAccessors.cs
+++ b/Kinetix/Tests/Kinetix.Broker.Test/ReferenceBroker/IReferenceAccessors.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.ServiceModel;
+using Kinetix.ServiceModel;
+
+namespace Kinetix.Broker.Test {
+    /// <summary>
+    /// Reference accessors.
+    /// </summary>
+    [ServiceContract]
+    public interface IReferenceAccessors {
+        /// <summary>
+        /// Reference accessor for type ReferenceBean.
+        /// </summary>
+        [ReferenceAccessor]
+        [OperationContract]
+        ICollection<ReferenceBean> LoadReferenceBeanList();
+    }
+}

--- a/Kinetix/Tests/Kinetix.Broker.Test/ReferenceBroker/ReferenceAccessors.cs
+++ b/Kinetix/Tests/Kinetix.Broker.Test/ReferenceBroker/ReferenceAccessors.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace Kinetix.Broker.Test {
+    /// <summary>
+    /// Reference accessors.
+    /// </summary>
+    public partial class ReferenceAccessors : IReferenceAccessors {
+        /// <summary>
+        /// Reference accessor for type ReferenceBean.
+        /// </summary>
+        /// <returns></returns>
+        public ICollection<ReferenceBean> LoadReferenceBeanList() {
+            return TestStore<ReferenceBean>.PutList;
+        }
+    }
+}

--- a/Kinetix/Tests/Kinetix.Broker.Test/ReferenceBroker/ReferenceBean.cs
+++ b/Kinetix/Tests/Kinetix.Broker.Test/ReferenceBroker/ReferenceBean.cs
@@ -1,0 +1,36 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Runtime.Serialization;
+using Kinetix.ComponentModel;
+
+namespace Kinetix.Broker.Test {
+    /// <summary>
+    /// Bean liste de référence avec traduction.
+    /// </summary>
+    [Reference]
+    [Table("BEAN")]
+    public class ReferenceBean {
+        /// <summary>
+        /// Identifiant.
+        /// </summary>
+        [DataMember(IsRequired = true)]
+        [Column("BEA_ID")]
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int? Id {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Libellé.
+        /// </summary>
+        [DataMember(IsRequired = true)]
+        [Translatable]
+        [Column("BEA_LIBELLE")]
+        public string Libelle {
+            get;
+            set;
+        }
+    }
+}

--- a/Kinetix/Tests/Kinetix.Broker.Test/ReferenceBroker/ReferenceBrokerMock.cs
+++ b/Kinetix/Tests/Kinetix.Broker.Test/ReferenceBroker/ReferenceBrokerMock.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Kinetix.ServiceModel;
+
+namespace Kinetix.Broker.Test {
+    /// <summary>
+    /// Surcharge de ReferenceBroker utilisant le TestStore.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class ReferenceBrokerMock<T> : ReferenceBroker<T>
+        where T : class, new() {
+        /// <summary>
+        /// Constructeur. Pas de surcharge particulière.
+        /// </summary>
+        /// <param name="dataSourceName">Nom de la source de données.</param>
+        /// <param name="resourceLoader">Service de chargement des ressources.</param>
+        /// <param name="resourceWriter">Service d'écriture des ressources.</param>
+        public ReferenceBrokerMock(string dataSourceName, IResourceLoader resourceLoader, IResourceWriter resourceWriter)
+            : base(dataSourceName, resourceLoader, resourceWriter) {
+        }
+
+        /// <summary>
+        /// Surcharge utilisant le TestStore.
+        /// </summary>
+        /// <param name="dataSourceName"></param>
+        /// <returns></returns>
+        protected override IStore<T> CreateStore(string dataSourceName) {
+            Type storeType = typeof(TestStore<>);
+            Type realStoreType = storeType.MakeGenericType(typeof(T));
+            return (IStore<T>)Activator.CreateInstance(realStoreType, dataSourceName);
+        }
+    }
+
+}

--- a/Kinetix/Tests/Kinetix.Broker.Test/ReferenceBroker/ReferenceBrokerTest.cs
+++ b/Kinetix/Tests/Kinetix.Broker.Test/ReferenceBroker/ReferenceBrokerTest.cs
@@ -1,0 +1,101 @@
+﻿using System.Linq;
+using Kinetix.ServiceModel;
+using System;
+using Microsoft.Practices.Unity;
+#if NUnit
+    using NUnit.Framework; 
+#else
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestFixtureAttribute = Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute;
+using TestAttribute = Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute;
+using SetUpAttribute = Microsoft.VisualStudio.TestTools.UnitTesting.TestInitializeAttribute;
+using TestFixtureSetUpAttribute = Microsoft.VisualStudio.TestTools.UnitTesting.ClassInitializeAttribute;
+#endif
+
+namespace Kinetix.Broker.Test {
+    /// <summary>
+    /// Classe de test du broker de référence.
+    /// </summary>
+    [TestFixture]
+    public class ReferenceBrokerTest {
+        private static Lazy<IUnityContainer> Container = new Lazy<IUnityContainer>(() => {
+            return new UnityContainer();
+        });
+
+        private ReferenceBrokerMock<ReferenceBean> Broker;
+
+        /// <summary>
+        /// Initialise le contexte des tests.
+        /// Exécuté une seule fois.
+        /// </summary>
+        /// <param name="context"></param>
+        [TestFixtureSetUp]
+        public static void TestFixtureSetUp(TestContext context = null) {
+            ServiceManager.Instance.Container = Container.Value;
+            ServiceManager.Instance.RegisterLocalService(typeof(IReferenceAccessors), typeof(ReferenceAccessors));
+
+        }
+
+        /// <summary>
+        /// Initialise le contexte des tests.
+        /// Exécuté pour chaque test.
+        /// </summary>
+        [SetUp]
+        public void SetUp() {
+            BrokerManager.Instance.RegisterStore("name", typeof(TestStore<>));
+            Broker = new ReferenceBrokerMock<ReferenceBean>("name", new ServiceResourceLoaderMock(), new ServiceResourceWriterMock());
+            ReferenceBrokerTestHelper.LangueCode = "EN";
+            TestStore<ReferenceBean>.ExceptionOnCall = false;
+        }
+
+        /// <summary>
+        /// Test le fonctionnement du constructeur.
+        /// </summary>
+        [Test]
+        public void TestConstructor() {
+            // Test SetUp.
+        }
+
+        /// <summary>
+        /// Test le bon fonctionnement du Save.
+        /// </summary>
+        [Test]
+        public void TestSave() {
+            Assert.IsNotNull(Broker.Save(new ReferenceBean { Libelle = "A" }, null));
+        }
+
+        /// <summary>
+        /// Test l'update dans la langue par défaut.
+        /// </summary>
+        [Test]
+        public void TestUpdateOnDefaultLanguage() {
+            ReferenceBean bean = new ReferenceBean { Libelle = "A" };
+            Assert.IsNotNull(Broker.Save(bean, null));
+            bean.Libelle = "B";
+            Assert.IsNotNull(Broker.Save(bean, null));
+
+            // Check that translation has been updated.
+            Assert.AreEqual("B", ReferenceBrokerTestHelper.Traduction.Last().Value);
+            // Check that value in store has been updated.
+            Assert.AreEqual("B", TestStore<ReferenceBean>.PutList.Last().Libelle);
+        }
+
+        /// <summary>
+        /// Test l'update dans une autre langue.
+        /// </summary>
+        [Test]
+        public void TestUpdateOnOtherLanguage() {
+            ReferenceBrokerTestHelper.LangueCode = "DE";
+
+            ReferenceBean bean = new ReferenceBean { Libelle = "A" };
+            Assert.IsNotNull(Broker.Save(bean, null));
+            bean.Libelle = "B";
+            Assert.IsNotNull(Broker.Save(bean, null));
+
+            // Check that translation has been updated.
+            Assert.AreEqual("B", ReferenceBrokerTestHelper.Traduction.Last().Value);
+            // Check that value in store has not been updated.
+            Assert.AreNotEqual("B", TestStore<ReferenceBean>.PutList.Last().Libelle);
+        }
+    }
+}

--- a/Kinetix/Tests/Kinetix.Broker.Test/ReferenceBroker/ReferenceBrokerTestHelper.cs
+++ b/Kinetix/Tests/Kinetix.Broker.Test/ReferenceBroker/ReferenceBrokerTestHelper.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Kinetix.Broker.Test {
+    /// <summary>
+    /// Helper contenant des propriétés static servant pour les différentes autres classes.
+    /// </summary>
+    public class ReferenceBrokerTestHelper {
+        /// <summary>
+        /// Code langue actuel. Peut être changé.
+        /// </summary>
+        public static string LangueCode = "EN";
+
+        /// <summary>
+        /// Dictionary: (property code, language) -> value
+        /// Représente la table de traduction.
+        /// </summary>
+        public static IDictionary<Tuple<string, string>, string> Traduction = new Dictionary<Tuple<string, string>, string>();
+    }
+
+}

--- a/Kinetix/Tests/Kinetix.Broker.Test/ReferenceBroker/ServiceResourceLoaderMock.cs
+++ b/Kinetix/Tests/Kinetix.Broker.Test/ReferenceBroker/ServiceResourceLoaderMock.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using Kinetix.ServiceModel;
+
+namespace Kinetix.Broker.Test {
+    /// <summary>
+    /// Implémentation simple de IResourceLoader.
+    /// S'appuie sur ReferenceBrokerTestHelper.
+    /// </summary>
+    public class ServiceResourceLoaderMock : IResourceLoader {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public string LoadCurrentLangueCode() {
+            return ReferenceBrokerTestHelper.LangueCode;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public string LoadLangueCodeDefaut() {
+            return "EN";
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="referenceType"></param>
+        /// <returns></returns>
+        public ICollection<ReferenceResource> LoadReferenceResourceListByReferenceType(Type referenceType) {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Kinetix/Tests/Kinetix.Broker.Test/ReferenceBroker/ServiceResourceWriterMock.cs
+++ b/Kinetix/Tests/Kinetix.Broker.Test/ReferenceBroker/ServiceResourceWriterMock.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Kinetix.ComponentModel;
+using Kinetix.ServiceModel;
+
+namespace Kinetix.Broker.Test {
+    /// <summary>
+    /// Implémentation simple de IResourceWriter.
+    /// S'appuie sur ReferenceBrokerTestHelper.
+    /// </summary>
+    public class ServiceResourceWriterMock : IResourceWriter {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="referenceType"></param>
+        /// <param name="primaryKey"></param>
+        public void DeleteTraductionReferenceByReferenceAndPrimaryKey(Type referenceType, object primaryKey) {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="referenceType"></param>
+        /// <param name="bean"></param>
+        /// <param name="cultureUI"></param>
+        public void SaveTraductionReference(Type referenceType, object bean, string cultureUI) {
+            SaveTraductionReferenceList(referenceType, new List<object> { bean }, cultureUI);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="referenceType"></param>
+        /// <param name="beanList"></param>
+        /// <param name="cultureUI"></param>
+        public void SaveTraductionReferenceList(Type referenceType, ICollection beanList, string cultureUI) {
+            BeanDefinition definition = BeanDescriptor.GetDefinition(referenceType);
+            ICollection<BeanPropertyDescriptor> translatablePropList = definition.Properties.Where(x => x.IsTranslatable).ToList();
+
+            foreach (object bean in beanList) {
+                foreach (BeanPropertyDescriptor property in translatablePropList) {
+                    object value = property.GetValue(bean);
+                    if (value != null) {
+                        string code = definition.PrimaryKey.GetValue(bean).ToString();
+                        string languageCode = ReferenceBrokerTestHelper.LangueCode;
+                        Tuple<string, string> key = new Tuple<string, string>(code, languageCode);
+                        ReferenceBrokerTestHelper.Traduction[key] = value.ToString();
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/Kinetix/Tests/Kinetix.Broker.Test/TestStore.cs
+++ b/Kinetix/Tests/Kinetix.Broker.Test/TestStore.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Transactions;
+using Kinetix.ComponentModel;
 using Kinetix.Data.SqlClient;
 
 namespace Kinetix.Broker.Test {
@@ -16,6 +17,7 @@ namespace Kinetix.Broker.Test {
         private static bool _callWithTransactionScope;
         private static bool _exceptionOnCall;
         private string _name;
+        private static int _nextId = 1;
 
         /// <summary>
         /// Crée un nouveau store.
@@ -152,8 +154,21 @@ namespace Kinetix.Broker.Test {
             if (_exceptionOnCall) {
                 throw new Exception();
             }
-            _putList.Add(bean);
-            return 1;
+
+            if (columnSelector != null) {
+                BeanDefinition definition = BeanDescriptor.GetDefinition(typeof(T));
+                T puttingBean = new T();
+                foreach (BeanPropertyDescriptor property in definition.Properties) {
+                    if (columnSelector.ColumnList.Contains(property.PropertyName)) {
+                        property.SetValue(puttingBean, property.GetValue(bean));
+                    }
+                }
+                _putList.Add(puttingBean);
+            } else {
+                _putList.Add(bean);
+            }
+
+            return _nextId++;
         }
 
         /// <summary>
@@ -229,8 +244,7 @@ namespace Kinetix.Broker.Test {
         /// <param name="criteria">Les critères de recherche.</param>
         /// <param name="returnNullIfZeroRow">Null if Zero.</param>
         /// <returns>Bean.</returns>
-        public T LoadByCriteria(T destination, FilterCriteria criteria, bool returnNullIfZeroRow = false)
-        {
+        public T LoadByCriteria(T destination, FilterCriteria criteria, bool returnNullIfZeroRow = false) {
             return new T();
         }
     }

--- a/Kinetix/Tests/Kinetix.Broker.Test/packages.config
+++ b/Kinetix/Tests/Kinetix.Broker.Test/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CommonServiceLocator" version="1.3" targetFramework="net462" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net462" />
   <package id="Microsoft.Net.Compilers" version="2.6.1" targetFramework="net462" developmentDependency="true" />
+  <package id="Unity" version="4.0.1" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
### Current behaviour
When saving a reference item on a custom language, labels in its table take the previous value in this language.

### Expected behaviour
Never edit labels in a reference table with custom language ones.